### PR TITLE
fix(ci): replace git-cliff Docker action with direct binary install

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,13 +18,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate CHANGELOG with git-cliff
-        uses: orhun/git-cliff-action@v3
-        with:
-          config: cliff.toml
-          args: --verbose
-        env:
-          OUTPUT: CHANGELOG.md
+      - name: Install git-cliff
+        run: |
+          curl -sSL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz --strip-components=1 git-cliff-*/git-cliff
+          sudo mv git-cliff /usr/local/bin/
+
+      - name: Generate CHANGELOG
+        run: git-cliff --config cliff.toml --verbose --output CHANGELOG.md
 
       - name: Commit updated CHANGELOG
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install git-cliff
+        run: |
+          curl -sSL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz --strip-components=1 git-cliff-*/git-cliff
+          sudo mv git-cliff /usr/local/bin/
+
       - name: Generate release notes with git-cliff
-        uses: orhun/git-cliff-action@v3
-        id: cliff
-        with:
-          config: cliff.toml
-          args: --latest --strip header
-        env:
-          OUTPUT: RELEASE_NOTES.md
+        run: git-cliff --config cliff.toml --latest --strip header --output RELEASE_NOTES.md
 
       - name: Get version from latest tag (or use date)
         id: version


### PR DESCRIPTION
orhun/git-cliff-action@v3 fails with Docker build errors on ubuntu-latest. Install the precompiled binary directly from GitHub releases instead.