### PR TITLE
fix(ci): replace broken curl/tar git-cliff install with taiki-e/insta…

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,10 +19,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install git-cliff
-        run: |
-          curl -sSL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz \
-            | tar -xz --strip-components=1 git-cliff-*/git-cliff
-          sudo mv git-cliff /usr/local/bin/
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
 
       - name: Generate CHANGELOG
         run: git-cliff --config cliff.toml --verbose --output CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install git-cliff
-        run: |
-          curl -sSL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz \
-            | tar -xz --strip-components=1 git-cliff-*/git-cliff
-          sudo mv git-cliff /usr/local/bin/
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
 
       - name: Generate release notes with git-cliff
         run: git-cliff --config cliff.toml --latest --strip header --output RELEASE_NOTES.md


### PR DESCRIPTION
…ll-action

The previous curl | tar command failed because the git-cliff Linux archive is flat (no subdirectory), making --strip-components=1 and the glob git-cliff-*/git-cliff invalid. Switch to taiki-e/install-action which handles binary download and PATH setup automatically.