### PR TITLE
ci: stabilize changelog and production release automation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,12 +4,22 @@ on:
   push:
     branches:
       - DEV
+    paths-ignore:
+      - CHANGELOG.md
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: changelog-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changelog:
-    name: Generate CHANGELOG
+    name: Generate CHANGELOG PR
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, 'auto-update CHANGELOG') }}
     permissions:
       contents: write
       pull-requests: write
@@ -30,41 +40,54 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Generate CHANGELOG
+      - name: Generate unreleased CHANGELOG section
         run: |
-          DATE=$(date +%Y-%m-%d)
+          set -euo pipefail
 
-          # Force-update today's tag to HEAD
-          git tag -f "$DATE"
-          git push origin --force "refs/tags/$DATE"
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
 
-          # Find the previous tag (last one that isn't today's)
-          PREV_TAG=$(git tag --sort=version:refname | grep -v "^${DATE}" | tail -1)
+          path = Path("CHANGELOG.md")
+          content = path.read_text(encoding="utf-8")
+          content = re.sub(
+              r"\n## \[Unreleased\].*?(?=\n## \[|\Z)",
+              "\n",
+              content,
+              count=1,
+              flags=re.S,
+          )
+          path.write_text(content.lstrip(), encoding="utf-8")
+          PY
 
-          # Remove today's section from CHANGELOG if it already exists
-          if grep -q "^## \[${DATE}\]" CHANGELOG.md; then
-            python3 -c "
-          import re, sys
-          date = sys.argv[1]
-          with open('CHANGELOG.md') as f:
-              content = f.read()
-          content = re.sub(r'## \[' + re.escape(date) + r'\].*?(?=\n## \[)', '', content, flags=re.DOTALL)
-          with open('CHANGELOG.md', 'w') as f:
-              f.write(content)
-          " "$DATE"
+          PREVIOUS_PROD_TAG=$(git tag --merged HEAD --list "v*" --sort=version:refname | tail -n 1 || true)
+
+          if [ -n "$PREVIOUS_PROD_TAG" ]; then
+            git-cliff --config cliff.toml "${PREVIOUS_PROD_TAG}..HEAD" --unreleased --prepend CHANGELOG.md
+          else
+            git-cliff --config cliff.toml --unreleased --prepend CHANGELOG.md
           fi
 
-          # Generate and prepend today's section
-          if [ -n "$PREV_TAG" ]; then
-            git-cliff --config cliff.toml "${PREV_TAG}..HEAD" --tag "$DATE" --prepend CHANGELOG.md
+      - name: Check changelog bot token
+        id: changelog-token
+        env:
+          CHANGELOG_BOT_TOKEN: ${{ secrets.CHANGELOG_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${CHANGELOG_BOT_TOKEN}" ]; then
+            echo "::notice::CHANGELOG_BOT_TOKEN is not configured; skipping changelog PR creation."
+            echo "available=false" >> "$GITHUB_OUTPUT"
           else
-            git-cliff --config cliff.toml --tag "$DATE" --prepend CHANGELOG.md
+            echo "available=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create Pull Request for CHANGELOG update
+        if: ${{ steps.changelog-token.outputs.available == 'true' }}
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "docs: auto-update CHANGELOG [skip ci]"
+          token: ${{ secrets.CHANGELOG_BOT_TOKEN }}
+          commit-message: "docs: auto-update CHANGELOG"
           branch: chore/auto-update-changelog
           delete-branch: true
           title: "docs: auto-update CHANGELOG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,20 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: production-release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    if: ${{ github.ref == 'refs/heads/main' }}
 
     steps:
       - name: Checkout repository (full history)
@@ -23,24 +30,115 @@ jobs:
         with:
           tool: git-cliff
 
-      - name: Generate release notes with git-cliff
-        run: git-cliff --config cliff.toml --latest --strip header --output RELEASE_NOTES.md
-
-      - name: Get version from latest tag (or use date)
+      - name: Resolve production release tag
         id: version
         run: |
-          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$TAG" ]; then
-            echo "name=v$(date +'%Y.%m.%d')" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          git fetch --force --tags
+
+          EXISTING_TAG=$(git tag --points-at HEAD --list "v*" | sort -V | tail -n 1 || true)
+
+          if [ -n "$EXISTING_TAG" ]; then
+            RELEASE_TAG="$EXISTING_TAG"
+            TAG_ALREADY_EXISTS=true
           else
-            echo "name=$TAG" >> $GITHUB_OUTPUT
+            BASE_TAG="v$(date -u +'%Y.%m.%d')"
+            RELEASE_TAG="$BASE_TAG"
+
+            if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+              RELEASE_TAG="${BASE_TAG}.${GITHUB_RUN_NUMBER}"
+            fi
+
+            TAG_ALREADY_EXISTS=false
           fi
+
+          PREVIOUS_TAG=$(git tag --merged HEAD --list "v*" | grep -v "^${RELEASE_TAG}$" | sort -V | tail -n 1 || true)
+
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+          echo "tag_already_exists=$TAG_ALREADY_EXISTS" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes with git-cliff
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ steps.version.outputs.previous_tag }}" ]; then
+            git-cliff --config cliff.toml "${{ steps.version.outputs.previous_tag }}..HEAD" --tag "${{ steps.version.outputs.release_tag }}" --strip header --output RELEASE_NOTES.md
+          else
+            git-cliff --config cliff.toml --tag "${{ steps.version.outputs.release_tag }}" --strip header --output RELEASE_NOTES.md
+          fi
+
+      - name: Create production tag
+        if: ${{ steps.version.outputs.tag_already_exists == 'false' }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.release_tag }}" -m "Release ${{ steps.version.outputs.release_tag }}"
+          git push origin "${{ steps.version.outputs.release_tag }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.version.outputs.name }}
-          name: Release ${{ steps.version.outputs.name }}
+          tag_name: ${{ steps.version.outputs.release_tag }}
+          name: Release ${{ steps.version.outputs.release_tag }}
           body_path: RELEASE_NOTES.md
           draft: false
           prerelease: false
+
+      - name: Notify Discord
+        env:
+          DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+          PREVIOUS_TAG: ${{ steps.version.outputs.previous_tag }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DISCORD_RELEASE_WEBHOOK_URL}" ]; then
+            echo "DISCORD_RELEASE_WEBHOOK_URL is not configured; skipping Discord notification."
+            exit 0
+          fi
+
+          python3 - <<'PY' > discord_payload.json
+          import json
+          import os
+          from pathlib import Path
+
+          tag = os.environ["RELEASE_TAG"]
+          previous_tag = os.environ.get("PREVIOUS_TAG") or "initial release"
+          repo = os.environ["GITHUB_REPOSITORY"]
+          sha = os.environ["GITHUB_SHA"][:7]
+          release_url = f"https://github.com/{repo}/releases/tag/{tag}"
+          notes = Path("RELEASE_NOTES.md").read_text(encoding="utf-8").strip()
+
+          if len(notes) > 3000:
+              notes = notes[:2950].rstrip() + "\n..."
+
+          payload = {
+              "username": "Koi's Story Releases",
+              "allowed_mentions": {"parse": []},
+              "embeds": [
+                  {
+                      "title": f"Production release {tag}",
+                      "url": release_url,
+                      "description": notes or "Release production publiee.",
+                      "color": 0xEAB21B,
+                      "fields": [
+                          {"name": "Branche", "value": "`main`", "inline": True},
+                          {"name": "Commit", "value": f"`{sha}`", "inline": True},
+                          {"name": "Depuis", "value": f"`{previous_tag}`", "inline": True},
+                          {"name": "GitHub Release", "value": f"[Voir la release]({release_url})", "inline": False},
+                      ],
+                  }
+              ],
+          }
+
+          print(json.dumps(payload))
+          PY
+
+          curl --fail --silent --show-error \
+            -X POST "$DISCORD_RELEASE_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data @discord_payload.json

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ The project documentation index is available in `docs/README.md`.
 
 ## Changelog
 
-Project history is tracked in `CHANGELOG.md`.
+Project history is tracked in `CHANGELOG.md`; release automation is documented in
+`docs/github/release_and_changelog.md`.
 
 ## Tech Stack
 
@@ -147,7 +148,7 @@ Project history is tracked in `CHANGELOG.md`.
 | Authentication   | Devise + devise-two-factor                                         |
 | Linter/Formatter | RuboCop + Biome                                                    |
 | Image upload     | CarrierWave + Cloudinary                                           |
-| Emails           | ActionMailer + Resend SMTP                                         |
+| Emails           | ActionMailer + Brevo SMTP                                          |
 | Hosting          | Coolify-ready Docker on VPS; Kamal config kept as legacy reference |
 
 ## Team

--- a/cliff.toml
+++ b/cliff.toml
@@ -11,19 +11,19 @@ This project follows a pre-production workflow until the first production deploy
 """
 
 body = """
-{% if version %}\
+{% if version %}
 ## [{{ version }}]
-{% else %}\
+{% else %}
 ## [Unreleased]
-
-{% endif %}\
+{% endif %}
 {% for group, commits in commits | group_by(attribute="group") %}
+
 ### {{ group }}
-{% for commit in commits %}\
+{% for commit in commits %}
 - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message }}
 {% endfor %}
 {% endfor %}
----
+
 """
 
 footer = ""
@@ -36,8 +36,11 @@ split_commits = false
 
 commit_parsers = [
   { message = "\\[skip ci\\]", skip = true },
-  { message = "^Merge", group = "Integration" },
+  { message = "auto-update CHANGELOG", skip = true },
+  { message = "^Merge pull request", skip = true },
+  { message = "^Merge branch", skip = true },
   { message = "^feat", group = "Added" },
+  { message = "^(add|added)(\\(.+\\))?:", group = "Added" },
   { message = "^fix", group = "Fixed" },
   { message = "^remove", group = "Removed" },
   { message = "^refactor", group = "Changed" },

--- a/docs/github/branching_and_protection.md
+++ b/docs/github/branching_and_protection.md
@@ -67,4 +67,5 @@ Re-verify the live settings in **Settings -> Branches** or **Rulesets**:
 
 - `CONTRIBUTING.md` - workflow and branch rules.
 - `.github/workflows/` - CI and release automation.
+- `docs/github/release_and_changelog.md` - changelog, release, and Discord notification flow.
 - `docs/deployment/coolify.md` - Coolify deployment target.

--- a/docs/github/release_and_changelog.md
+++ b/docs/github/release_and_changelog.md
@@ -1,0 +1,100 @@
+# Release and changelog automation
+
+This document describes the expected automation for the Koi's Story GitHub
+release flow.
+
+## Goals
+
+- Keep `DEV` as the integration branch.
+- Keep `main` as the production release branch.
+- Generate changelog updates from commit messages.
+- Create immutable production tags only from `main`.
+- Send a Discord embed when a production release is published.
+
+## DEV changelog flow
+
+The `Update CHANGELOG` workflow runs after pushes to `DEV`, except when only
+`CHANGELOG.md` changed.
+
+It creates or updates a pull request named:
+
+```text
+docs: auto-update CHANGELOG
+```
+
+The workflow updates the `Unreleased` section from commits since the latest
+production tag matching `v*`. It does not create tags and does not force-push
+tags.
+
+Required repository secret:
+
+```text
+CHANGELOG_BOT_TOKEN
+```
+
+Use a fine-grained GitHub token or GitHub App token that can write contents and
+pull requests for this repository. This is needed because pull requests created
+with the built-in `GITHUB_TOKEN` may not trigger required checks under branch
+protection.
+
+If this secret is absent, the workflow still generates the changelog locally in
+the runner, but it skips pull request creation to avoid opening a blocked bot PR.
+
+## Production release flow
+
+The `Create Release` workflow runs when `main` receives a push, or manually via
+`workflow_dispatch`.
+
+It resolves a production tag:
+
+- reuses an existing `v*` tag if `HEAD` is already tagged;
+- otherwise creates `vYYYY.MM.DD`;
+- if that tag already exists, creates `vYYYY.MM.DD.<run_number>`.
+
+Release notes are generated with `git-cliff` from the previous production tag
+to `HEAD`. Date-only staging tags are ignored because the workflow only looks
+for tags matching `v*`.
+
+## Discord notification
+
+Production release notifications are sent after the GitHub Release is created.
+
+Required repository secret:
+
+```text
+DISCORD_RELEASE_WEBHOOK_URL
+```
+
+Create the webhook in the target Discord channel, then store the full webhook
+URL as a GitHub Actions secret. If the secret is absent, the release still
+succeeds and the Discord step is skipped.
+
+The workflow sends a Discord embed containing:
+
+- release tag;
+- `main` branch;
+- commit SHA;
+- previous production tag;
+- GitHub Release link;
+- generated release notes.
+
+## Commit message contract
+
+The changelog groups commits by conventional prefixes:
+
+- `feat:` and `add:` -> Added
+- `fix:` and `revert:` -> Fixed
+- `remove:` -> Removed
+- `refactor:`, `style:`, `perf:`, `chore:`, `docs:`, `test:`, `build:`, `ci:` -> Changed
+
+Merge commits and automatic changelog commits are skipped to avoid duplicated
+noise in release notes.
+
+## Human checklist
+
+1. Keep feature work in branches targeting `DEV`.
+2. Merge validated feature PRs into `DEV`.
+3. Let the automatic changelog PR update `CHANGELOG.md`.
+4. Promote `DEV` to `main` only when production is ready.
+5. Confirm the GitHub Release exists.
+6. Confirm the Discord release embed arrived in the expected channel.


### PR DESCRIPTION
## Summary
- stop force-updating daily tags from the DEV changelog workflow
- generate CHANGELOG updates through a dedicated PR without [skip ci]
- create immutable production v* tags and GitHub Releases from main
- send an optional Discord release embed via DISCORD_RELEASE_WEBHOOK_URL
- document the required CHANGELOG_BOT_TOKEN and Discord webhook setup

## Validation
- ruby YAML parse for changelog/release workflows
- git diff --check
- LF line-ending check for modified workflow/config files

## Manual follow-up
- add GitHub secret CHANGELOG_BOT_TOKEN if the automatic changelog PR must trigger required checks
- add GitHub secret DISCORD_RELEASE_WEBHOOK_URL for Discord release embeds