### PR TITLE
fix: isolate Docker test database

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker compose build
 docker compose up -d --wait db public admin
 docker compose exec -T admin bin/rails db:seed
 ruby script/docker_smoke.rb
-docker compose run --rm -e KOIS_APP_ROLE=all -e RAILS_ENV=test public bash -lc "unset DATABASE_URL; bin/rails test"
+docker compose run --rm -e KOIS_APP_ROLE=all -e RAILS_ENV=test public bin/rails test
 docker compose exec -T public bundle exec rubocop
 ```
 
@@ -87,6 +87,8 @@ Local services:
 - public site: `http://localhost:3000` (`KOIS_APP_ROLE=public`)
 - admin site: `http://localhost:3001` (`KOIS_APP_ROLE=admin`)
 - PostgreSQL: `127.0.0.1:5433`
+
+Rails tests run against `kois_story_test` through `TEST_DATABASE_URL`; they must not reuse or wipe the local development database.
 
 The Docker smoke script checks the public/admin route split, shared database, service health, and LF endings for Rails binstubs.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,13 +22,15 @@ services:
     command: >
       bash -lc "unset SOLID_QUEUE_IN_PUMA &&
       bundle install &&
-      bin/rails db:prepare"
+      bin/rails db:prepare &&
+      RAILS_ENV=test bin/rails db:prepare"
     env_file:
       - .env.local
     environment:
       BUNDLE_PATH: /bundle
       DATABASE_URL: postgres://kois_story:kois_story@db:5432/kois_story_development
       RAILS_ENV: development
+      TEST_DATABASE_URL: postgres://kois_story:kois_story@db:5432/kois_story_test
     depends_on:
       db:
         condition: service_healthy
@@ -55,6 +57,7 @@ services:
       PORT: "3000"
       PUBLIC_SITE_URL: http://localhost:3000
       RAILS_ENV: development
+      TEST_DATABASE_URL: postgres://kois_story:kois_story@db:5432/kois_story_test
     depends_on:
       db:
         condition: service_healthy
@@ -85,6 +88,7 @@ services:
       PORT: "3001"
       PUBLIC_SITE_URL: http://localhost:3000
       RAILS_ENV: development
+      TEST_DATABASE_URL: postgres://kois_story:kois_story@db:5432/kois_story_test
     depends_on:
       db:
         condition: service_healthy

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,8 +17,9 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: storage/test.sqlite3
+  url: <%= ENV.fetch("TEST_DATABASE_URL", "sqlite3:storage/test.sqlite3") %>
+  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
 
 # Store production database in the storage/ directory, which by default
 # is mounted as a persistent Docker volume in config/deploy.yml.

--- a/docs/development/local-docker.md
+++ b/docs/development/local-docker.md
@@ -33,7 +33,7 @@ docker compose build
 docker compose up -d --wait db public admin
 docker compose exec -T admin bin/rails db:seed
 ruby script/docker_smoke.rb
-docker compose run --rm -e KOIS_APP_ROLE=all -e RAILS_ENV=test public bash -lc "unset DATABASE_URL; bin/rails test"
+docker compose run --rm -e KOIS_APP_ROLE=all -e RAILS_ENV=test public bin/rails test
 docker compose exec -T public bundle exec rubocop
 ```
 
@@ -56,6 +56,11 @@ Les services `public` et `admin` partagent la même base PostgreSQL Docker.
 Le routage reste séparé par rôle : les routes admin ne doivent pas répondre sur
 `:3000`, et les routes publiques ne doivent pas répondre sur `:3001` quand elles
 sont hors périmètre admin.
+
+Les tests Rails utilisent une base PostgreSQL séparée, `kois_story_test`, via
+`TEST_DATABASE_URL`. Ne pas contourner cela avec `unset DATABASE_URL` : la base
+de développement `kois_story_development` doit rester intacte après un
+`bin/rails test`.
 
 ## Commandes utiles
 


### PR DESCRIPTION
## Résumé
- sépare les tests Docker sur `kois_story_test` via `TEST_DATABASE_URL`
- prépare la base test dans le service `setup`
- met à jour le README et la documentation Docker locale

## Vérifications
- `docker compose config --quiet`
- `ruby script/docker_smoke.rb`
- `docker compose run --rm -e KOIS_APP_ROLE=all -e RAILS_ENV=test public bin/rails test`
- `docker compose exec -T public bundle exec rubocop`
- vérification que `RAILS_ENV=test` utilise `kois_story_test`
- vérification que `kois_story_development` garde les seeds après les tests

## Note
Les notes Obsidian locales liées à Docker ont aussi été mises à jour en français sur la machine.