### PR TITLE
fix: improve navbar dropdown contrast

### DIFF
--- a/app/assets/stylesheets/visitors/header-section-2.css
+++ b/app/assets/stylesheets/visitors/header-section-2.css
@@ -48,6 +48,9 @@
 	display: block;
 	padding: var(--sp-2) var(--sp-5);
 	white-space: nowrap;
+	color: rgba(255, 255, 255, 0.82);
+	font-weight: 600;
+	text-decoration: none;
 	transition:
 		background var(--t-fast),
 		color var(--t-fast);


### PR DESCRIPTION
## Résumé
- rend les liens du dropdown `Produits` lisibles sur le fond sombre
- garde le hover gold et la cohérence avec la palette navbar

## Vérifications
- rendu Playwright desktop 1440 : dropdown ouvert, liens en `rgba(255, 255, 255, 0.82)`
- `npx biome check app/assets/stylesheets/visitors/header-section-2.css`
- `git diff --check`