### PR TITLE
fix: stabilize admin koi photo upload layout

### DIFF
--- a/app/assets/stylesheets/admin/forms-section-2.css
+++ b/app/assets/stylesheets/admin/forms-section-2.css
@@ -1,6 +1,13 @@
 /* Split from ADMIN/assets/css/forms.css - section 2/2 */
 /* ── FILE UPLOAD ─────────────────────────────────────────── */
 .upload-zone {
+	display: flex;
+	width: 100%;
+	min-height: 170px;
+	box-sizing: border-box;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
 	border: 2px dashed var(--border-color);
 	border-radius: 10px;
 	padding: 28px 20px;


### PR DESCRIPTION
## Résumé
- corrige le cadre dashed cassé sur la section Photos de l'édition admin des koïs
- force `.upload-zone` en bloc flex pleine largeur avec hauteur stable
- garde le fichier CSS sous la limite de 200 lignes

## Vérifications
- rendu Playwright sur `/admin/kois/:id/edit` : upload-zone pleine largeur, bordure dashed complète
- `npx biome check app/assets/stylesheets/admin/forms-section-2.css`
- `git diff --check`