### PR TITLE
style: soften select dropdown menus

### DIFF
--- a/app/assets/stylesheets/admin_application.css
+++ b/app/assets/stylesheets/admin_application.css
@@ -30,6 +30,7 @@
 @import url("./shared/select-control.css");
 @import url("./shared/select-dropdown.css");
 @import url("./shared/scrollbar.css");
+@import url("./shared/native-controls.css");
 
 *,
 *::before,

--- a/app/assets/stylesheets/admin_application.css
+++ b/app/assets/stylesheets/admin_application.css
@@ -29,6 +29,7 @@
 @import url("./admin/pages/admin-responsive.css");
 @import url("./shared/select-control.css");
 @import url("./shared/select-dropdown.css");
+@import url("./shared/scrollbar.css");
 
 *,
 *::before,

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -29,3 +29,4 @@
 @import url("./shared/select-control.css");
 @import url("./shared/select-dropdown.css");
 @import url("./shared/scrollbar.css");
+@import url("./shared/native-controls.css");

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,3 +28,4 @@
 @import url("./visitors/toast.css");
 @import url("./shared/select-control.css");
 @import url("./shared/select-dropdown.css");
+@import url("./shared/scrollbar.css");

--- a/app/assets/stylesheets/shared/native-controls.css
+++ b/app/assets/stylesheets/shared/native-controls.css
@@ -1,0 +1,168 @@
+/* Shared polish for browser-native form controls. */
+input,
+textarea {
+	caret-color: var(--or-konishi, var(--c-gold, #eab21b));
+}
+
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+	appearance: none;
+	-webkit-appearance: none;
+	display: none;
+}
+
+input[type="number"] {
+	appearance: textfield;
+	-moz-appearance: textfield;
+}
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+	appearance: none;
+	-webkit-appearance: none;
+	margin: 0;
+}
+
+input[type="date"],
+input[type="datetime-local"],
+input[type="time"] {
+	color-scheme: light;
+}
+
+input[type="date"]::-webkit-calendar-picker-indicator,
+input[type="datetime-local"]::-webkit-calendar-picker-indicator,
+input[type="time"]::-webkit-calendar-picker-indicator {
+	width: 18px;
+	height: 18px;
+	padding: 4px;
+	border-radius: 999px;
+	cursor: pointer;
+	background-color: rgba(var(--or-konishi-rgb, 234, 178, 27), 0.16);
+	transition:
+		background-color 0.16s ease,
+		transform 0.16s ease;
+}
+
+input[type="date"]::-webkit-calendar-picker-indicator:hover,
+input[type="datetime-local"]::-webkit-calendar-picker-indicator:hover,
+input[type="time"]::-webkit-calendar-picker-indicator:hover {
+	background-color: rgba(var(--or-konishi-rgb, 234, 178, 27), 0.28);
+	transform: translateY(-1px);
+}
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+textarea:-webkit-autofill,
+textarea:-webkit-autofill:hover,
+textarea:-webkit-autofill:focus {
+	border-color: rgba(var(--or-konishi-rgb, 234, 178, 27), 0.7);
+	box-shadow: 0 0 0 1000px var(--blanc-pur, var(--c-white, #fff)) inset;
+	-webkit-text-fill-color: var(--noir, var(--c-black, #000));
+	transition: background-color 9999s ease-in-out 0s;
+}
+
+input[type="checkbox"]:not(.toggle-input):not(#konishi-toggle) {
+	appearance: none;
+	-webkit-appearance: none;
+	display: inline-grid;
+	place-content: center;
+	width: 18px;
+	height: 18px;
+	margin: 0;
+	flex: 0 0 18px;
+	vertical-align: middle;
+	background:
+		linear-gradient(
+			135deg,
+			rgba(var(--or-konishi-rgb, 234, 178, 27), 0.1),
+			transparent
+		),
+		var(--blanc-pur, var(--c-white, #fff));
+	border: 1.5px solid rgba(var(--bronze-rgb, 165, 130, 65), 0.58);
+	border-radius: 5px;
+	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.72) inset;
+	cursor: pointer;
+	transition:
+		background 0.16s ease,
+		border-color 0.16s ease,
+		box-shadow 0.16s ease;
+}
+
+input[type="checkbox"]:not(.toggle-input):not(#konishi-toggle)::after {
+	content: "";
+	width: 10px;
+	height: 10px;
+	transform: scale(0);
+	transition: transform 0.12s ease;
+	background: var(--bleu-nuit, var(--c-navy, #011325));
+	clip-path: polygon(14% 44%, 0 60%, 38% 100%, 100% 18%, 83% 0, 36% 66%);
+}
+
+input[type="checkbox"]:not(.toggle-input):not(#konishi-toggle):checked {
+	background: linear-gradient(
+		135deg,
+		var(--or-konishi, #eab21b),
+		var(--bronze, #a58241)
+	);
+	border-color: var(--or-konishi, #eab21b);
+	box-shadow: 0 0 0 3px rgba(var(--or-konishi-rgb, 234, 178, 27), 0.18);
+}
+
+input[type="checkbox"]:not(.toggle-input):not(#konishi-toggle):checked::after,
+input[type="checkbox"]:not(.toggle-input):not(
+		#konishi-toggle
+	):indeterminate::after {
+	transform: scale(1);
+}
+
+input[type="checkbox"]:not(.toggle-input):not(
+		#konishi-toggle
+	):indeterminate::after {
+	height: 2px;
+	clip-path: none;
+	border-radius: 999px;
+}
+
+input[type="checkbox"]:not(.toggle-input):not(#konishi-toggle):focus-visible {
+	outline: none;
+	box-shadow:
+		0 0 0 3px rgba(var(--or-konishi-rgb, 234, 178, 27), 0.24),
+		0 8px 18px rgba(1, 19, 37, 0.1);
+}
+
+.filter-toggle input[type="checkbox"] {
+	width: 36px;
+	height: 20px;
+	flex-basis: 36px;
+	border-radius: var(--r-full, 999px);
+	place-content: initial;
+	background: var(--n-17);
+	border-color: transparent;
+	box-shadow: none;
+}
+
+.filter-toggle input[type="checkbox"]::after {
+	width: 16px;
+	height: 16px;
+	clip-path: none;
+	background: var(--c-white, #fff);
+	transform: none;
+}
+
+.filter-toggle input[type="checkbox"]:checked::after {
+	transform: translateX(16px);
+}
+
+.filter-toggle
+	input[type="checkbox"]:not(.toggle-input):not(#konishi-toggle):checked {
+	background: var(--c-wine);
+	border-color: transparent;
+	box-shadow: none;
+}
+
+.contact-form__human-label input[type="checkbox"] {
+	margin-top: 2px;
+}

--- a/app/assets/stylesheets/shared/scrollbar.css
+++ b/app/assets/stylesheets/shared/scrollbar.css
@@ -1,0 +1,46 @@
+:root {
+	--scrollbar-size: 8px;
+	--scrollbar-track: rgba(1, 19, 37, 0.07);
+	--scrollbar-thumb: rgba(165, 130, 65, 0.72);
+	--scrollbar-thumb-start: var(--or-konishi, var(--c-gold, #eab21b));
+	--scrollbar-thumb-end: var(--bronze, var(--c-bronze, #a58241));
+	--scrollbar-thumb-border: var(--blanc-pur, var(--c-white, #fff));
+}
+
+* {
+	scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+	scrollbar-width: thin;
+}
+
+*::-webkit-scrollbar {
+	width: var(--scrollbar-size);
+	height: var(--scrollbar-size);
+}
+
+*::-webkit-scrollbar-track {
+	background: var(--scrollbar-track);
+	border-radius: 999px;
+}
+
+*::-webkit-scrollbar-thumb {
+	background: linear-gradient(
+		180deg,
+		var(--scrollbar-thumb-start),
+		var(--scrollbar-thumb-end)
+	);
+	background-clip: padding-box;
+	border: 2px solid var(--scrollbar-thumb-border);
+	border-radius: 999px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+	background: linear-gradient(
+		180deg,
+		var(--scrollbar-thumb-start),
+		var(--scrollbar-thumb-end)
+	);
+}
+
+*::-webkit-scrollbar-corner {
+	background: transparent;
+}

--- a/app/assets/stylesheets/shared/scrollbar.css
+++ b/app/assets/stylesheets/shared/scrollbar.css
@@ -1,10 +1,9 @@
 :root {
 	--scrollbar-size: 8px;
-	--scrollbar-track: rgba(1, 19, 37, 0.07);
+	--scrollbar-track: rgba(165, 130, 65, 0.16);
 	--scrollbar-thumb: rgba(165, 130, 65, 0.72);
 	--scrollbar-thumb-start: var(--or-konishi, var(--c-gold, #eab21b));
 	--scrollbar-thumb-end: var(--bronze, var(--c-bronze, #a58241));
-	--scrollbar-thumb-border: var(--blanc-pur, var(--c-white, #fff));
 }
 
 * {
@@ -28,8 +27,6 @@
 		var(--scrollbar-thumb-start),
 		var(--scrollbar-thumb-end)
 	);
-	background-clip: padding-box;
-	border: 2px solid var(--scrollbar-thumb-border);
 	border-radius: 999px;
 }
 

--- a/app/assets/stylesheets/shared/scrollbar.css
+++ b/app/assets/stylesheets/shared/scrollbar.css
@@ -14,6 +14,7 @@
 *::-webkit-scrollbar {
 	width: var(--scrollbar-size);
 	height: var(--scrollbar-size);
+	background: transparent;
 }
 
 *::-webkit-scrollbar-track {
@@ -21,10 +22,22 @@
 	border-radius: 999px;
 }
 
+*::-webkit-scrollbar-track-piece {
+	background: transparent;
+}
+
 *::-webkit-scrollbar-button {
 	display: none;
 	width: 0;
 	height: 0;
+	background: transparent;
+}
+
+*::-webkit-scrollbar-button:single-button {
+	display: none;
+	width: 0;
+	height: 0;
+	background: transparent;
 }
 
 *::-webkit-scrollbar-thumb {
@@ -46,4 +59,47 @@
 
 *::-webkit-scrollbar-corner {
 	background: transparent;
+}
+
+html.ks-custom-scrollbar {
+	scrollbar-width: none;
+}
+
+html.ks-custom-scrollbar::-webkit-scrollbar,
+html.ks-custom-scrollbar body::-webkit-scrollbar {
+	display: none;
+	width: 0;
+	height: 0;
+	background: transparent;
+}
+
+.ks-scrollbar-thumb {
+	position: fixed;
+	top: 0;
+	right: 2px;
+	z-index: 2147483000;
+	width: 5px;
+	height: var(--ks-scrollbar-height, 48px);
+	background: linear-gradient(
+		180deg,
+		var(--scrollbar-thumb-start),
+		var(--scrollbar-thumb-end)
+	);
+	border-radius: 999px;
+	opacity: 0;
+	pointer-events: auto;
+	touch-action: none;
+	transform: translateY(var(--ks-scrollbar-top, 0));
+	transition:
+		opacity 160ms ease,
+		width 160ms ease;
+}
+
+html.ks-custom-scrollbar-ready .ks-scrollbar-thumb {
+	opacity: 0.9;
+}
+
+html.ks-custom-scrollbar-ready .ks-scrollbar-thumb:hover,
+html.ks-custom-scrollbar-dragging .ks-scrollbar-thumb {
+	width: 7px;
 }

--- a/app/assets/stylesheets/shared/scrollbar.css
+++ b/app/assets/stylesheets/shared/scrollbar.css
@@ -1,6 +1,6 @@
 :root {
-	--scrollbar-size: 8px;
-	--scrollbar-track: rgba(165, 130, 65, 0.16);
+	--scrollbar-size: 7px;
+	--scrollbar-track: transparent;
 	--scrollbar-thumb: rgba(165, 130, 65, 0.72);
 	--scrollbar-thumb-start: var(--or-konishi, var(--c-gold, #eab21b));
 	--scrollbar-thumb-end: var(--bronze, var(--c-bronze, #a58241));
@@ -19,6 +19,12 @@
 *::-webkit-scrollbar-track {
 	background: var(--scrollbar-track);
 	border-radius: 999px;
+}
+
+*::-webkit-scrollbar-button {
+	display: none;
+	width: 0;
+	height: 0;
 }
 
 *::-webkit-scrollbar-thumb {

--- a/app/assets/stylesheets/shared/select-dropdown.css
+++ b/app/assets/stylesheets/shared/select-dropdown.css
@@ -128,6 +128,12 @@
 	border-radius: 999px;
 }
 
+.ks-select__menu::-webkit-scrollbar-button {
+	display: none;
+	width: 0;
+	height: 0;
+}
+
 .ks-select__menu::-webkit-scrollbar-thumb {
 	background: linear-gradient(
 		180deg,

--- a/app/assets/stylesheets/shared/select-dropdown.css
+++ b/app/assets/stylesheets/shared/select-dropdown.css
@@ -119,30 +119,6 @@
 	scrollbar-width: thin;
 }
 
-.ks-select__menu::-webkit-scrollbar {
-	width: 8px;
-}
-
-.ks-select__menu::-webkit-scrollbar-track {
-	background: var(--scrollbar-track, rgba(1, 19, 37, 0.07));
-	border-radius: 999px;
-}
-
-.ks-select__menu::-webkit-scrollbar-button {
-	display: none;
-	width: 0;
-	height: 0;
-}
-
-.ks-select__menu::-webkit-scrollbar-thumb {
-	background: linear-gradient(
-		180deg,
-		var(--scrollbar-thumb-start, #eab21b),
-		var(--scrollbar-thumb-end, #a58241)
-	);
-	border-radius: 999px;
-}
-
 .ks-select__option {
 	display: flex;
 	align-items: center;

--- a/app/assets/stylesheets/shared/select-dropdown.css
+++ b/app/assets/stylesheets/shared/select-dropdown.css
@@ -103,15 +103,34 @@
 	left: 0;
 	z-index: 180;
 	width: max(100%, 220px);
-	max-height: 280px;
+	max-height: 232px;
 	padding: 7px;
 	overflow-y: auto;
 	background:
-		linear-gradient(145deg, rgba(234, 178, 27, 0.14), transparent 34%),
-		rgba(1, 19, 37, 0.97);
-	border: 1px solid rgba(234, 178, 27, 0.3);
+		linear-gradient(145deg, rgba(234, 178, 27, 0.12), transparent 34%),
+		var(--blanc-pur, var(--c-white, #fff));
+	border: 1px solid rgba(165, 130, 65, 0.28);
 	border-radius: 12px;
-	box-shadow: 0 20px 44px rgba(1, 19, 37, 0.3);
+	box-shadow:
+		0 18px 36px rgba(1, 19, 37, 0.16),
+		0 0 0 1px rgba(255, 255, 255, 0.7) inset;
+	scrollbar-color: rgba(165, 130, 65, 0.72) rgba(1, 19, 37, 0.07);
+	scrollbar-width: thin;
+}
+
+.ks-select__menu::-webkit-scrollbar {
+	width: 8px;
+}
+
+.ks-select__menu::-webkit-scrollbar-track {
+	background: rgba(1, 19, 37, 0.06);
+	border-radius: 999px;
+}
+
+.ks-select__menu::-webkit-scrollbar-thumb {
+	background: linear-gradient(180deg, #eab21b, #a58241);
+	border: 2px solid var(--blanc-pur, var(--c-white, #fff));
+	border-radius: 999px;
 }
 
 .ks-select__option {
@@ -120,7 +139,7 @@
 	width: 100%;
 	min-height: 34px;
 	padding: 8px 10px;
-	color: rgba(255, 255, 255, 0.86);
+	color: var(--bleu-nuit, var(--c-navy, #011325));
 	font: inherit;
 	font-size: 0.88rem;
 	font-weight: 650;
@@ -129,18 +148,28 @@
 	border: 0;
 	border-radius: 8px;
 	cursor: pointer;
+	transition:
+		background 140ms ease,
+		color 140ms ease;
 }
 
 .ks-select__option:hover,
 .ks-select__option:focus-visible {
-	color: var(--bleu-nuit, var(--c-navy, #011325));
-	background: var(--or-konishi, var(--c-gold, #eab21b));
+	color: var(--blanc-pur, var(--c-white, #fff));
+	background: var(--bleu-nuit, var(--c-navy, #011325));
 	outline: none;
 }
 
 .ks-select__option.is-selected {
 	color: var(--bleu-nuit, var(--c-navy, #011325));
 	background: linear-gradient(135deg, #eab21b, #f4cf55);
+	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.6) inset;
+}
+
+.ks-select__option.is-selected:hover,
+.ks-select__option.is-selected:focus-visible {
+	color: var(--bleu-nuit, var(--c-navy, #011325));
+	background: linear-gradient(135deg, #f0c43b, #eab21b);
 }
 
 .ks-select.is-disabled {

--- a/app/assets/stylesheets/shared/select-dropdown.css
+++ b/app/assets/stylesheets/shared/select-dropdown.css
@@ -114,7 +114,8 @@
 	box-shadow:
 		0 18px 36px rgba(1, 19, 37, 0.16),
 		0 0 0 1px rgba(255, 255, 255, 0.7) inset;
-	scrollbar-color: rgba(165, 130, 65, 0.72) rgba(1, 19, 37, 0.07);
+	scrollbar-color: var(--scrollbar-thumb, rgba(165, 130, 65, 0.72))
+		var(--scrollbar-track, rgba(1, 19, 37, 0.07));
 	scrollbar-width: thin;
 }
 
@@ -123,13 +124,17 @@
 }
 
 .ks-select__menu::-webkit-scrollbar-track {
-	background: rgba(1, 19, 37, 0.06);
+	background: var(--scrollbar-track, rgba(1, 19, 37, 0.07));
 	border-radius: 999px;
 }
 
 .ks-select__menu::-webkit-scrollbar-thumb {
-	background: linear-gradient(180deg, #eab21b, #a58241);
-	border: 2px solid var(--blanc-pur, var(--c-white, #fff));
+	background: linear-gradient(
+		180deg,
+		var(--scrollbar-thumb-start, #eab21b),
+		var(--scrollbar-thumb-end, #a58241)
+	);
+	border: 2px solid var(--scrollbar-thumb-border, var(--blanc-pur, #fff));
 	border-radius: 999px;
 }
 

--- a/app/assets/stylesheets/shared/select-dropdown.css
+++ b/app/assets/stylesheets/shared/select-dropdown.css
@@ -134,7 +134,6 @@
 		var(--scrollbar-thumb-start, #eab21b),
 		var(--scrollbar-thumb-end, #a58241)
 	);
-	border: 2px solid var(--scrollbar-thumb-border, var(--blanc-pur, #fff));
 	border-radius: 999px;
 }
 

--- a/app/assets/stylesheets/visitors/shop-section-1.css
+++ b/app/assets/stylesheets/visitors/shop-section-1.css
@@ -111,7 +111,12 @@
 	cursor: pointer;
 }
 .shop-card__btn:hover {
-	background: linear-gradient(135deg, var(--c-gold), var(--c-bronze), var(--c-gold));
+	background: linear-gradient(
+		135deg,
+		var(--c-gold),
+		var(--c-bronze),
+		var(--c-gold)
+	);
 	background-size: 200% 200%;
 	background-position: 100% 100%;
 	border-color: var(--c-gold);

--- a/app/assets/stylesheets/visitors/shop-section-1.css
+++ b/app/assets/stylesheets/visitors/shop-section-1.css
@@ -23,7 +23,10 @@
 .shop-card__thumb {
 	position: relative;
 	aspect-ratio: 4 / 3;
-	background: var(--n-08);
+	background:
+		radial-gradient(circle at center, var(--c-gold-20) 0%, transparent 48%),
+		linear-gradient(145deg, rgba(234, 178, 27, 0.1), rgba(1, 19, 37, 0.06)),
+		var(--n-08);
 	overflow: hidden;
 }
 .shop-card__thumb img {
@@ -44,8 +47,13 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 3rem;
-	color: var(--n-17);
+	font-size: 3.35rem;
+	color: var(--c-bronze);
+	text-shadow: 0 10px 26px rgba(165, 130, 65, 0.35);
+	transition: transform var(--t-slow);
+}
+.shop-card:hover .shop-card__icon {
+	transform: scale(1.05);
 }
 
 .shop-card__thumb .badge {
@@ -86,23 +94,29 @@
 	display: block;
 	width: 100%;
 	padding: var(--sp-2) var(--sp-4);
-	background: transparent;
-	color: var(--c-wine);
-	border: 2px solid var(--c-wine);
+	background: var(--c-gold-10);
+	color: var(--c-black);
+	border: 2px solid var(--c-bronze);
 	border-radius: var(--r-full);
 	text-align: center;
 	font-family: var(--font-sans);
 	font-size: var(--text-sm);
 	font-weight: 700;
 	transition:
-		background var(--t-fast),
-		color var(--t-fast);
+		background-position 0.6s linear,
+		border-color var(--t-fast),
+		box-shadow var(--t-fast),
+		transform var(--t-fast);
 	text-decoration: none;
 	cursor: pointer;
 }
 .shop-card__btn:hover {
-	background: var(--c-wine);
-	color: var(--c-white);
+	background: linear-gradient(135deg, var(--c-gold), var(--c-bronze), var(--c-gold));
+	background-size: 200% 200%;
+	background-position: 100% 100%;
+	border-color: var(--c-gold);
+	box-shadow: 0 10px 24px rgba(234, 178, 27, 0.28);
+	transform: translateY(-1px);
 }
 
 /* ── SHOP SECTION ────────────────────────────────────────────────────── */

--- a/app/javascript/admin/admin.js
+++ b/app/javascript/admin/admin.js
@@ -31,7 +31,7 @@ document.addEventListener("turbo:load", () => {
 		this.classList.remove("active");
 	});
 
-	document.addEventListener("click", (e) => {
+	document.addEventListener("click", async (e) => {
 		const copyButton = e.target.closest("[data-copy-target]");
 		if (copyButton) {
 			const target = document.querySelector(copyButton.dataset.copyTarget);
@@ -46,7 +46,9 @@ document.addEventListener("turbo:load", () => {
 		if (!logoutButton) return;
 
 		e.preventDefault();
-		if (!confirm("Voulez-vous vraiment vous déconnecter ?")) return;
+		const confirmation = window.AdminConfirm || ((message) => Promise.resolve(confirm(message)));
+		const confirmed = await confirmation("Voulez-vous vraiment vous déconnecter ?");
+		if (!confirmed) return;
 
 		const logoutForm = logoutButton.closest("form");
 		if (logoutForm) {

--- a/app/javascript/admin/confirm-dialog.js
+++ b/app/javascript/admin/confirm-dialog.js
@@ -1,0 +1,69 @@
+(() => {
+	let activeDialog;
+
+	const template = () => {
+		const overlay = document.createElement("div");
+		overlay.className = "modal-overlay modal-overlay--open";
+		overlay.dataset.adminConfirm = "true";
+		overlay.innerHTML = `
+      <div class="modal modal--sm" role="dialog" aria-modal="true" aria-labelledby="admin-confirm-title">
+        <div class="modal-header">
+          <h2 class="modal-title" id="admin-confirm-title">Confirmation</h2>
+          <button type="button" class="modal-close" data-confirm-cancel aria-label="Fermer">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="modal-confirm-icon" aria-hidden="true">!</div>
+          <p class="modal-confirm-text" data-confirm-message></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn--outline" data-confirm-cancel>Annuler</button>
+          <button type="button" class="btn btn--danger" data-confirm-accept>Confirmer</button>
+        </div>
+      </div>`;
+		return overlay;
+	};
+
+	const closeDialog = (dialog, result, resolve, previousFocus) => {
+		dialog.remove();
+		activeDialog = null;
+		document.body.style.overflow = "";
+		previousFocus?.focus?.();
+		resolve(result);
+	};
+
+	const confirmDialog = (message) =>
+		new Promise((resolve) => {
+			activeDialog?.remove();
+			const previousFocus = document.activeElement;
+			const dialog = template();
+			activeDialog = dialog;
+			dialog.querySelector("[data-confirm-message]").textContent = message;
+			document.body.appendChild(dialog);
+			document.body.style.overflow = "hidden";
+			dialog.querySelector("[data-confirm-cancel]")?.focus();
+
+			const finish = (result) => closeDialog(dialog, result, resolve, previousFocus);
+
+			dialog.addEventListener("click", (event) => {
+				if (
+					event.target === dialog ||
+					event.target.closest("[data-confirm-cancel]")
+				) {
+					finish(false);
+				}
+				if (event.target.closest("[data-confirm-accept]")) finish(true);
+			});
+
+			dialog.addEventListener("keydown", (event) => {
+				if (event.key === "Escape") finish(false);
+			});
+		});
+
+	const install = () => {
+		window.AdminConfirm = confirmDialog;
+		window.Turbo?.setConfirmMethod?.(confirmDialog);
+	};
+
+	document.addEventListener("turbo:load", install);
+	install();
+})();

--- a/app/javascript/admin_application.js
+++ b/app/javascript/admin_application.js
@@ -1,5 +1,6 @@
 import "@hotwired/turbo-rails";
 import "controllers";
+import "admin/confirm-dialog";
 import "admin/admin";
 import "admin/notifications";
 import "admin/kois";

--- a/app/javascript/admin_application.js
+++ b/app/javascript/admin_application.js
@@ -9,3 +9,4 @@ import "admin/orders";
 import "admin/payments";
 import "admin/bulk-actions";
 import "shared/select-dropdown";
+import "shared/scrollbar";

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,3 +9,4 @@ import "visitors/toast";
 import "visitors/contact-form";
 import "visitors/turnstile";
 import "shared/select-dropdown";
+import "shared/scrollbar";

--- a/app/javascript/shared/scrollbar.js
+++ b/app/javascript/shared/scrollbar.js
@@ -1,0 +1,101 @@
+(() => {
+	let controller;
+	let frame;
+	let thumb;
+	let dragging = false;
+	let dragStartY = 0;
+	let dragStartScroll = 0;
+
+	const root = document.documentElement;
+
+	const maxScroll = () =>
+		Math.max(0, root.scrollHeight - window.innerHeight);
+
+	const update = () => {
+		frame = undefined;
+		if (!thumb) return;
+
+		const max = maxScroll();
+		const active = max > 4;
+		root.classList.toggle("ks-custom-scrollbar-ready", active);
+		if (!active) return;
+
+		const viewport = window.innerHeight;
+		const height = Math.max(42, Math.round((viewport / root.scrollHeight) * viewport));
+		const top = Math.round((window.scrollY / max) * (viewport - height));
+
+		thumb.style.setProperty("--ks-scrollbar-height", `${height}px`);
+		thumb.style.setProperty("--ks-scrollbar-top", `${top}px`);
+	};
+
+	const scheduleUpdate = () => {
+		if (frame) return;
+		frame = window.requestAnimationFrame(update);
+	};
+
+	const dragTo = (clientY) => {
+		const max = maxScroll();
+		const available = Math.max(1, window.innerHeight - thumb.offsetHeight);
+		const delta = clientY - dragStartY;
+		window.scrollTo(0, dragStartScroll + (delta / available) * max);
+	};
+
+	const stopDrag = () => {
+		if (!dragging) return;
+		dragging = false;
+		root.classList.remove("ks-custom-scrollbar-dragging");
+	};
+
+	const startDrag = (event) => {
+		if (event.button !== 0) return;
+		event.preventDefault();
+		dragging = true;
+		dragStartY = event.clientY;
+		dragStartScroll = window.scrollY;
+		root.classList.add("ks-custom-scrollbar-dragging");
+		thumb.setPointerCapture?.(event.pointerId);
+	};
+
+	const init = () => {
+		cleanup();
+		controller = new AbortController();
+		root.classList.add("ks-custom-scrollbar");
+
+		thumb = document.createElement("div");
+		thumb.className = "ks-scrollbar-thumb";
+		thumb.setAttribute("aria-hidden", "true");
+		document.body.appendChild(thumb);
+
+		const signal = controller.signal;
+		window.addEventListener("scroll", scheduleUpdate, { passive: true, signal });
+		window.addEventListener("resize", scheduleUpdate, { signal });
+		thumb.addEventListener("pointerdown", startDrag, { signal });
+		window.addEventListener(
+			"pointermove",
+			(event) => {
+				if (dragging) dragTo(event.clientY);
+			},
+			{ signal },
+		);
+		window.addEventListener("pointerup", stopDrag, { signal });
+		window.addEventListener("pointercancel", stopDrag, { signal });
+		scheduleUpdate();
+	};
+
+	function cleanup() {
+		controller?.abort();
+		if (frame) window.cancelAnimationFrame(frame);
+		frame = undefined;
+		dragging = false;
+		thumb?.remove();
+		thumb = undefined;
+		root.classList.remove(
+			"ks-custom-scrollbar",
+			"ks-custom-scrollbar-ready",
+			"ks-custom-scrollbar-dragging",
+		);
+	}
+
+	document.addEventListener("turbo:load", init);
+	document.addEventListener("turbo:before-cache", cleanup);
+})();

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,32 @@
-<h2>Resend confirmation instructions</h2>
+<% content_for :title, "Confirmation - Admin | Koi's Story" %>
+<% content_for :body_class, "login-page" %>
+<% content_for :extra_stylesheet, "admin_application" %>
+<% content_for :skip_default_footer, true %>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div id="form-ui">
+  <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { id: "form", method: :post }) do |f| %>
+    <div id="form-body">
+      <div id="welcome-lines">
+        <%= image_tag "/logo_bg_circle_dark_v2.avif", alt: "Koi's Story", class: "login-logo-img" %>
+        <div id="welcome-line-1">Koi's Story</div>
+        <div id="welcome-line-2">Confirmation</div>
+      </div>
 
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %></p>
-  </div>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
-<% end %>
+      <div id="input-area">
+        <div class="form-inp">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Adresse email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), required: true %>
+        </div>
+      </div>
 
-<%= render "devise/shared/links" %>
+      <div id="submit-button-cvr">
+        <%= f.submit "Renvoyer les instructions", id: "submit-button" %>
+      </div>
+
+      <div id="forgot-pass">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,40 @@
-<h2>Change your password</h2>
+<% content_for :title, "Nouveau mot de passe - Admin | Koi's Story" %>
+<% content_for :body_class, "login-page" %>
+<% content_for :extra_stylesheet, "admin_application" %>
+<% content_for :skip_default_footer, true %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+<div id="form-ui">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { id: "form", method: :put }) do |f| %>
+    <div id="form-body">
+      <div id="welcome-lines">
+        <%= image_tag "/logo_bg_circle_dark_v2.avif", alt: "Koi's Story", class: "login-logo-img" %>
+        <div id="welcome-line-1">Koi's Story</div>
+        <div id="welcome-line-2">Nouveau mot de passe</div>
+      </div>
 
-  <div class="field">
-    <p><%= f.label :password, "New password" %></p>
-    <% if @minimum_password_length %>
-      <p><em>(<%= @minimum_password_length %> characters minimum)</em></p>
-    <% end %>
-    <p><%= f.password_field :password, autofocus: true, autocomplete: "new-password" %></p>
-  </div>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <p><%= f.label :password_confirmation, "Confirm new password" %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
+      <div id="input-area">
+        <div class="form-inp">
+          <%= f.password_field :password, autofocus: true, autocomplete: "new-password", placeholder: "Nouveau mot de passe", required: true %>
+        </div>
+        <div class="form-inp">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "Confirmer le mot de passe", required: true %>
+        </div>
+      </div>
 
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
+      <% if @minimum_password_length %>
+        <div class="cloudinary-note"><%= @minimum_password_length %> caractères minimum.</div>
+      <% end %>
 
-<%= render "devise/shared/links" %>
+      <div id="submit-button-cvr">
+        <%= f.submit "Changer le mot de passe", id: "submit-button" %>
+      </div>
+
+      <div id="forgot-pass">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,32 @@
-<h2>Forgot your password?</h2>
+<% content_for :title, "Mot de passe oublié - Admin | Koi's Story" %>
+<% content_for :body_class, "login-page" %>
+<% content_for :extra_stylesheet, "admin_application" %>
+<% content_for :skip_default_footer, true %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div id="form-ui">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { id: "form", method: :post }) do |f| %>
+    <div id="form-body">
+      <div id="welcome-lines">
+        <%= image_tag "/logo_bg_circle_dark_v2.avif", alt: "Koi's Story", class: "login-logo-img" %>
+        <div id="welcome-line-1">Koi's Story</div>
+        <div id="welcome-line-2">Réinitialisation</div>
+      </div>
 
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
-  </div>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="actions">
-    <%= f.submit "Send me password reset instructions" %>
-  </div>
-<% end %>
+      <div id="input-area">
+        <div class="form-inp">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Adresse email", required: true %>
+        </div>
+      </div>
 
-<%= render "devise/shared/links" %>
+      <div id="submit-button-cvr">
+        <%= f.submit "Envoyer le lien", id: "submit-button" %>
+      </div>
+
+      <div id="forgot-pass">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,21 @@
 <%- if controller_name != 'sessions' %>
-  <p><%= link_to "Log in", new_session_path(resource_name) %></p>
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <p><%= link_to "Sign up", new_registration_path(resource_name) %></p>
+  <p><%= link_to "Retour à la connexion", new_session_path(resource_name) %></p>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <p><%= link_to "Forgot your password?", new_password_path(resource_name) %></p>
+  <p><%= link_to "Mot de passe oublié ?", new_password_path(resource_name) %></p>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <p><%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %></p>
+  <p><%= link_to "Instructions de confirmation non reçues ?", new_confirmation_path(resource_name) %></p>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <p><%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %></p>
+  <p><%= link_to "Instructions de déverrouillage non reçues ?", new_unlock_path(resource_name) %></p>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <p><%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %></p>
+    <p><%= button_to "Se connecter avec #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %></p>
   <% end %>
 <% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,16 +1,32 @@
-<h2>Resend unlock instructions</h2>
+<% content_for :title, "Déverrouillage - Admin | Koi's Story" %>
+<% content_for :body_class, "login-page" %>
+<% content_for :extra_stylesheet, "admin_application" %>
+<% content_for :skip_default_footer, true %>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div id="form-ui">
+  <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { id: "form", method: :post }) do |f| %>
+    <div id="form-body">
+      <div id="welcome-lines">
+        <%= image_tag "/logo_bg_circle_dark_v2.avif", alt: "Koi's Story", class: "login-logo-img" %>
+        <div id="welcome-line-1">Koi's Story</div>
+        <div id="welcome-line-2">Déverrouillage</div>
+      </div>
 
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
-  </div>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
-  </div>
-<% end %>
+      <div id="input-area">
+        <div class="form-inp">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Adresse email", required: true %>
+        </div>
+      </div>
 
-<%= render "devise/shared/links" %>
+      <div id="submit-button-cvr">
+        <%= f.submit "Renvoyer les instructions", id: "submit-button" %>
+      </div>
+
+      <div id="forgot-pass">
+        <%= render "devise/shared/links" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,7 +3,7 @@
     <h3>Contact</h3>
     <%= form_with model: Message.new, url: messages_path, local: true do |f| %>
       <div>
-        <%= f.label :sender_name, "Name" %>
+        <%= f.label :sender_name, "Nom" %>
         <%= f.text_field :sender_name, required: true %>
       </div>
       <div>
@@ -14,7 +14,7 @@
         <%= f.label :body, "Message" %>
         <%= f.text_area :body, rows: 4, required: true %>
       </div>
-      <%= f.submit "Send message" %>
+      <%= f.submit "Envoyer le message" %>
     <% end %>
   </section>
 </footer>

--- a/app/views/pages/_shop_category.html.erb
+++ b/app/views/pages/_shop_category.html.erb
@@ -3,12 +3,20 @@
   <div class="shop-grid">
     <% items.each_with_index do |item, index| %>
       <article class="shop-card" data-animate="fade-up" data-delay="<%= index %>">
-        <div class="shop-card__thumb"><span class="badge"><%= item[:badge] %></span></div>
+        <div class="shop-card__thumb">
+          <span class="shop-card__icon" aria-hidden="true"><%= item[:icon] %></span>
+          <span class="badge"><%= item[:badge] %></span>
+        </div>
         <div class="shop-card__body">
           <h3 class="shop-card__name"><%= item[:name] %></h3>
           <p class="shop-card__desc"><%= item[:description] %></p>
         </div>
-        <div class="shop-card__footer"><button class="shop-card__btn" type="button">En savoir plus</button></div>
+        <div class="shop-card__footer">
+          <%= link_to "Demander conseil",
+                      root_path(anchor: "contact"),
+                      class: "shop-card__btn",
+                      aria: { label: "Demander conseil pour #{item[:name]}" } %>
+        </div>
       </article>
     <% end %>
   </div>

--- a/test/controllers/devise_pages_controller_test.rb
+++ b/test/controllers/devise_pages_controller_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class DevisePagesControllerTest < ActionDispatch::IntegrationTest
+  test "password reset page renders without disabled registration links" do
+    skip "Admin routes disabled for this app role" unless respond_to?(:new_user_password_path)
+
+    get new_user_password_path
+
+    assert_response :success
+    assert_select "a[href='/users/sign_up']", count: 0
+  end
+end


### PR DESCRIPTION
## Résumé
- adoucit le rendu des dropdowns custom ajoutés côté public/admin
- remplace le menu bleu nuit massif par une surface claire opaque plus intégrée aux tableaux admin
- garde les accents bronze / Konishi Gold, ajoute une scrollbar plus discrète et limite la hauteur du menu

## Vérifications
- npx biome check app/assets/stylesheets/shared/select-dropdown.css
- git diff --check HEAD~1..HEAD
- vérification Playwright sur /admin/kois avec dropdown ouvert